### PR TITLE
Add hover tooltips for customizable story points

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-FROM alpine AS builder
-# Install SSL ca certificates.
-# Ca-certificates is required to call HTTPS endpoints.
-RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
+WORKDIR /src
+COPY . .
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+RUN GOOS=linux GOARCH=$(echo $TARGETPLATFORM | cut -d'/' -f2) go build -o /full-house ./cmd/fullhouse
 
 FROM scratch
-
-# Import from builder.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
 ADD /config/fullhouse-default.yaml /app/config/
-ADD /full-house /app/
 ADD /frontend/dist/browser /app/frontend
-
+COPY --from=builder /full-house /app/full-house
 WORKDIR /app
-
 CMD ["/app/full-house", "server"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ helm repo add philmtd https://philmtd.github.io/helm-charts
 Full House runs perfectly fine with the default configuration.
 
 ### Customising voting schemes
-It is possible to adjust the available voting schemes from which the users can choose when creating a new game. 
+It is possible to adjust the available voting schemes from which the users can choose when creating a new game.
 Per default, there are the following two schemes available:
 
 ```yaml
@@ -57,6 +57,43 @@ of the Full House installation directory.
 Each scheme needs a name, the numbers available to vote (need to be 0 or greater, can be floating point numbers) and you can define whether
 to include a questionmark `?` voting card or not. If you use a custom config, the defaults will be overwritten, so if you want to include the default
  schemes, just copy them into your configuration.
+
+
+### Customizing story point tooltips
+
+You can configure the story point (Fibonacci) value/description pairs shown as tooltips on voting cards via YAML, not just in the frontend code. This allows you to provide custom explanations for each card, including 0 and '?', for your team.
+
+Add a `storyPointsMapping` section to your config:
+
+```yaml
+fullHouse:
+  storyPointsMapping:
+    - value: 0
+      description: No estimate / Not started
+    - value: 1
+      description: Less than an hour of work
+    - value: 2
+      description: A couple hours of work
+    - value: 3
+      description: A few hours of work
+    - value: 5
+      description: About a day of work
+    - value: 8
+      description: Several days of work
+    - value: 13
+      description: About a week of work
+    - value: 21
+      description: Multiple weeks of work
+    - value: 34
+      description: A month or more of work
+    - value: 55
+      description: Several months of work
+    - value: 89
+      description: Major project, multiple quarters
+    # You can add more or fewer values as needed
+```
+
+If this section is present, the backend will serve it at `/api/storyPointsMapping` and the frontend will use it for all story point tooltips. If not present, the default mapping is used.
 
 ### Persistent games
 
@@ -93,7 +130,7 @@ Practically these should not appear as problems at the scale this app is intende
 The UI has light and dark modes:
 
 | Voting                                           | Results                                            |
-|--------------------------------------------------|----------------------------------------------------|
+| ------------------------------------------------ | -------------------------------------------------- |
 | ![Voting in light mode](./docs/voting-light.png) | ![Results in light mode](./docs/results-light.png) |
 | ![Voting in light mode](./docs/voting-dark.png)  | ![Results in dark mode](./docs/results-dark.png)   |
 
@@ -168,7 +205,7 @@ The frontend will be available on port `4200`.
 To run the backend, run the `fullhouse/cmd/fullhouse` package with the `server` argument:
 
 ```yaml
-go run fullhouse/cmd/fullhouse server 
+go run fullhouse/cmd/fullhouse server
 ```
 
 This can of course be configured as a run configuration in your favorite IDE.

--- a/config/fullhouse.yaml
+++ b/config/fullhouse.yaml
@@ -1,8 +1,6 @@
 fullHouse:
   server:
     port: 8080
-    # No cookieDomain; using ctx.Request.Host for cookie domain (legacy logic)
-    # cookieSecure is ignored in this mode
   metrics:
     port: 8090
   mode: production

--- a/config/fullhouse.yaml
+++ b/config/fullhouse.yaml
@@ -1,6 +1,42 @@
 fullHouse:
-  mode: development
+  server:
+    port: 8080
+    # No cookieDomain; using ctx.Request.Host for cookie domain (legacy logic)
+    # cookieSecure is ignored in this mode
+  metrics:
+    port: 8090
+  mode: production
+  votingSchemes:
+    - name: LeanFibonacci
+      scheme: [1, 3, 5, 8, 13, 21]
+      includesQuestionmark: false
+    - name: Fibonacci
+      scheme: [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
+      includesQuestionmark: true
   persistentGames:
-    - name: Test Persistent Game
+    - name: Persistent
       slug: persistent_game
-      votingSchemeName: Fibonacci
+      votingSchemeName: LeanFibonacci
+  storyPointsMapping:
+    - value: 0
+      description: No estimate / Not started
+    - value: 1
+      description: Less than an hour of work
+    - value: 2
+      description: A couple hours of work
+    - value: 3
+      description: A few hours of work
+    - value: 5
+      description: About a day of work
+    - value: 8
+      description: Several days of work
+    - value: 13
+      description: About a week of work
+    - value: 21
+      description: Multiple weeks of work
+    - value: 34
+      description: A month or more of work
+    - value: 55
+      description: Several months of work
+    - value: 89
+      description: Major project, multiple quarters

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -42,6 +42,7 @@ import {TranslateHttpLoader} from "@ngx-translate/http-loader";
 import {TranslateMessageFormatCompiler} from "ngx-translate-messageformat-compiler";
 import {QRCodeModule} from "angularx-qrcode";
 import {SettingsState} from "./store/settings/settings.state";
+import {StoryPointsSettingsState} from "./store/settings/story-points-settings.state";
 import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
 
 export function HttpLoaderFactory(http: HttpClient) {
@@ -73,7 +74,7 @@ export function HttpLoaderFactory(http: HttpClient) {
         FormsModule,
         HttpClientModule,
         NgxsModule.forRoot(appStates, {developmentMode: !environment.production}),
-        NgxsStoragePluginModule.forRoot({key: [UserState, ThemingState, SettingsState]}),
+        NgxsStoragePluginModule.forRoot({key: [UserState, ThemingState, SettingsState, StoryPointsSettingsState]}),
         NgxsReduxDevtoolsPluginModule.forRoot(),
         NgxsLoggerPluginModule.forRoot(),
         MatIconModule,

--- a/frontend/src/app/components/story-points/story-points.component.html
+++ b/frontend/src/app/components/story-points/story-points.component.html
@@ -1,0 +1,16 @@
+<div class="story-points-container">
+  <h2>Story Points</h2>
+  <div class="story-points">
+    <ng-container *ngIf="storyPoints$ | async as storyPoints">
+      <div
+        class="point"
+        *ngFor="let sp of storyPoints"
+        [attr.title]="sp.description"
+        tabindex="0"
+      >
+        {{ sp.value }}
+      </div>
+    </ng-container>
+  </div>
+</div>
+

--- a/frontend/src/app/components/story-points/story-points.component.scss
+++ b/frontend/src/app/components/story-points/story-points.component.scss
@@ -1,0 +1,34 @@
+.story-points-container {
+  padding: 20px;
+  text-align: center;
+
+  h2 {
+    margin-bottom: 20px;
+    color: var(--text-color);
+  }
+}
+
+.story-points {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.point {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background-color: var(--primary-color);
+  color: var(--text-on-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  cursor: pointer;
+  transition: transform 0.2s;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+}

--- a/frontend/src/app/components/story-points/story-points.component.ts
+++ b/frontend/src/app/components/story-points/story-points.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { Select, Store } from '@ngxs/store';
+import { Observable } from 'rxjs';
+import { StoryPointsSettingsState, StoryPointMapping } from '../../store/settings/story-points-settings.state';
+import { SetCustomStoryPoints } from '../../store/settings/story-points-settings.actions';
+
+@Component({
+  selector: 'app-story-points',
+  templateUrl: './story-points.component.html',
+  styleUrls: ['./story-points.component.scss']
+})
+export class StoryPointsComponent {
+  @Select(StoryPointsSettingsState.customStoryPoints) storyPoints$!: Observable<StoryPointMapping[]>;
+
+  constructor(private store: Store) {}
+
+  setCustomStoryPoints(newPoints: StoryPointMapping[]) {
+    this.store.dispatch(new SetCustomStoryPoints(newPoints));
+  }
+}

--- a/frontend/src/app/game/game/game.component.html
+++ b/frontend/src/app/game/game/game.component.html
@@ -89,13 +89,15 @@
   <div class="bottom-menu fx-layout-row fx-align--center-x fx-align--x-center fx-gap--1em">
     @if (game.phase == 'VOTING') {
       <div class="bottom-menu-container">
-        @for (option of game.votingScheme.scheme; track option) {
-          <div class="card" (click)="selectOption(option)" [class.selected]="this.game.self?.vote?.vote == option">
-            <span>{{ option | fraction }}</span>
-          </div>
-        }
+        <ng-container *ngIf="storyPoints$ | async as storyPoints">
+          @for (option of game.votingScheme.scheme; track option) {
+            <div class="card" (click)="selectOption(option)" [class.selected]="this.game.self?.vote?.vote == option" [matTooltip]="getStoryPointDescription(option, storyPoints)">
+              <span>{{ option | fraction }}</span>
+            </div>
+          }
+        </ng-container>
         @if (game.votingScheme.includesQuestionmark) {
-          <div class="card" (click)="selectOption('?')" [class.selected]="this.game.self?.vote?.vote == '?'">
+          <div class="card" (click)="selectOption('?')" [class.selected]="this.game.self?.vote?.vote == '?'" [matTooltip]="'Unknown'">
             <span>{{ '?' }}</span>
           </div>
         }

--- a/frontend/src/app/game/game/game.component.ts
+++ b/frontend/src/app/game/game/game.component.ts
@@ -11,6 +11,7 @@ import {WebsocketApi} from "../api/websocket-api.service";
 import {first, map, tap} from "rxjs/operators";
 import {InvitePlayersDialogComponent} from "../../components/invite-players-dialog/invite-players-dialog.component";
 import {calculateAgreement, isVoteNumerical} from "./agreement";
+import { StoryPointsSettingsState, StoryPointMapping } from '../../store/settings/story-points-settings.state';
 
 export interface GameModel {
   name: string;
@@ -45,6 +46,9 @@ export class GameComponent {
   @Select(UserState.currentUser)
   public currentUser$: Observable<Participant>;
 
+  @Select(StoryPointsSettingsState.customStoryPoints)
+  storyPoints$!: Observable<StoryPointMapping[]>;
+
   constructor(route: ActivatedRoute,
               private api: Api,
               private store: Store,
@@ -55,12 +59,13 @@ export class GameComponent {
   }
 
   private initGame(slug: string | null) {
-    try {
-      if (slug == null) {
-        throw Error("slug is null")
-      }
-      this.slug = slug;
-      this.api.getGame(slug).subscribe(g => {
+    if (!slug) {
+      this.isError = true;
+      return;
+    }
+    this.slug = slug;
+    this.api.getGame(slug).subscribe({
+      next: g => {
         this.currentUser$.subscribe(currentUser => {
           if (!currentUser) {
             this.createUser();
@@ -85,12 +90,12 @@ export class GameComponent {
               });
           }
         });
-      }, _ => {
+      },
+      error: err => {
+        // If getGame fails (404), show error or optionally create the game here
         this.isError = true;
-      })
-    } catch (e) {
-
-    }
+      }
+    });
   }
 
   private setNextPhaseButtonDisabledState(gameState: GameState) {
@@ -110,9 +115,24 @@ export class GameComponent {
     this.dialog.open(CreateUserDialogComponent, {
       width: '80%'
     }).afterClosed().subscribe(participant => {
-      this.store.dispatch(new SetCurrentUser(participant))
-        .subscribe(() => this.wsApi.reconnect());
-    })
+      if (!participant) return;
+      this.store.dispatch(new SetCurrentUser(participant)).subscribe(() => {
+        // Always try to join the game after user creation
+        if (this.slug) {
+          this.api.joinGame(this.slug, participant).subscribe({
+            next: () => {
+              this.wsApi.reconnect();
+            },
+            error: err => {
+              // If join fails, show error and do not reconnect
+              this.isError = true;
+            }
+          });
+        } else {
+          this.wsApi.reconnect();
+        }
+      });
+    });
   }
 
   private toParticipantModel(game: Game, participant: Participant): ParticipantModel {
@@ -197,5 +217,15 @@ export class GameComponent {
         this.store.dispatch(new SetCurrentUser(participant));
       });
     });
+  }
+
+  getStoryPointDescription(option: number, storyPoints: StoryPointMapping[]): string {
+    if (option === 0) {
+      // fallback if not found in mapping
+      const found = storyPoints.find(sp => sp.value === 0);
+      return found ? found.description : 'No estimate / Not started';
+    }
+    const found = storyPoints.find(sp => sp.value === option);
+    return found ? found.description : '';
   }
 }

--- a/frontend/src/app/store/index.ts
+++ b/frontend/src/app/store/index.ts
@@ -1,9 +1,11 @@
 import {UserState} from "./user/user.state";
 import {ThemingState} from "./theming/theming.state";
 import {SettingsState} from "./settings/settings.state";
+import {StoryPointsSettingsState} from "./settings/story-points-settings.state";
 
 export const appStates = [
   ThemingState,
   UserState,
-  SettingsState
+  SettingsState,
+  StoryPointsSettingsState
 ];

--- a/frontend/src/app/store/settings/story-points-settings.actions.ts
+++ b/frontend/src/app/store/settings/story-points-settings.actions.ts
@@ -1,0 +1,10 @@
+import { StoryPointMapping } from './story-points-settings.state';
+
+export class LoadStoryPointsMapping {
+  static readonly type = '[Settings] Load Story Points Mapping';
+}
+
+export class SetCustomStoryPoints {
+  static readonly type = '[Settings] Set Custom Story Points';
+  constructor(public payload: StoryPointMapping[]) {}
+}

--- a/frontend/src/app/store/settings/story-points-settings.state.ts
+++ b/frontend/src/app/store/settings/story-points-settings.state.ts
@@ -1,0 +1,69 @@
+import { State, Action, StateContext, Selector, NgxsOnInit } from '@ngxs/store';
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { tap, catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { LoadStoryPointsMapping, SetCustomStoryPoints } from './story-points-settings.actions';
+
+export interface StoryPointMapping {
+  value: number;
+  description: string;
+}
+
+export interface StoryPointsSettingsStateModel {
+  customStoryPoints: StoryPointMapping[];
+}
+
+
+const defaultStoryPoints: StoryPointMapping[] = [
+  { value: 0, description: 'No estimate / Not started' },
+  { value: 1, description: 'Less than an hour of work' },
+  { value: 2, description: 'A couple hours of work' },
+  { value: 3, description: 'A few hours of work' },
+  { value: 5, description: 'About a day of work' },
+  { value: 8, description: 'Several days of work' },
+  { value: 13, description: 'About a week of work' },
+  { value: 21, description: 'Multiple weeks of work' },
+  { value: 34, description: 'A month or more of work' },
+  { value: 55, description: 'Several months of work' },
+  { value: 89, description: 'Major project, multiple quarters' }
+];
+
+const defaultState: StoryPointsSettingsStateModel = {
+  customStoryPoints: defaultStoryPoints
+};
+
+@State<StoryPointsSettingsStateModel>({
+  name: 'storyPointsSettings',
+  defaults: defaultState
+})
+@Injectable()
+export class StoryPointsSettingsState implements NgxsOnInit {
+  constructor(private http: HttpClient) {}
+
+  @Selector()
+  static customStoryPoints(state: StoryPointsSettingsStateModel) {
+    return state.customStoryPoints;
+  }
+
+  ngxsOnInit(ctx: StateContext<StoryPointsSettingsStateModel>) {
+    ctx.dispatch(new LoadStoryPointsMapping());
+  }
+
+  @Action(LoadStoryPointsMapping)
+  loadStoryPointsMapping(ctx: StateContext<StoryPointsSettingsStateModel>) {
+    return this.http.get<StoryPointMapping[]>('/api/storyPointsMapping').pipe(
+      tap((mapping) => {
+        if (Array.isArray(mapping) && mapping.length > 0) {
+          ctx.dispatch(new SetCustomStoryPoints(mapping));
+        }
+      }),
+      catchError(() => of(null))
+    );
+  }
+
+  @Action(SetCustomStoryPoints)
+  setCustomStoryPoints(ctx: StateContext<StoryPointsSettingsStateModel>, action: SetCustomStoryPoints) {
+    ctx.patchState({ customStoryPoints: action.payload });
+  }
+}

--- a/pkg/fullhouse/config/config.go
+++ b/pkg/fullhouse/config/config.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"strings"
+
+	"github.com/spf13/viper"
 )
 
 var Configuration Config
@@ -49,17 +50,24 @@ type Config struct {
 }
 
 type GameConfig struct {
-	Server          ServerConfig           `yaml:"server" validate:"required"`
-	Metrics         MetricsConfig          `yaml:"metrics" validate:"required"`
-	Mode            Mode                   `yaml:"mode"`
-	VotingSchemes   []VotingScheme         `yaml:"votingSchemes" validate:"required,dive"`
-	PersistentGames []PersistentGameConfig `yaml:"persistentGames" validate:"dive"`
+	Server             ServerConfig           `yaml:"server" validate:"required"`
+	Metrics            MetricsConfig          `yaml:"metrics" validate:"required"`
+	Mode               Mode                   `yaml:"mode"`
+	VotingSchemes      []VotingScheme         `yaml:"votingSchemes" validate:"required,dive"`
+	PersistentGames    []PersistentGameConfig `yaml:"persistentGames" validate:"dive"`
+	StoryPointsMapping []StoryPointMapping    `yaml:"storyPointsMapping" json:"storyPointsMapping"`
 }
 
 type VotingScheme struct {
-	Name                 string    `yaml:"name" json:"name" validate:"required"`
-	Scheme               []float32 `yaml:"scheme" json:"scheme" validate:"required,dive,number,min=0"`
+	Name                 string    `yaml:"name" json:"name"`
+	Scheme               []float32 `yaml:"scheme" json:"scheme"`
 	IncludesQuestionmark bool      `yaml:"includesQuestionmark" json:"includesQuestionmark"`
+}
+
+// StoryPointMapping allows customizing the value/description pairs for story points.
+type StoryPointMapping struct {
+	Value       float64 `yaml:"value" json:"value"`
+	Description string  `yaml:"description" json:"description"`
 }
 type Mode string
 
@@ -69,7 +77,8 @@ const (
 )
 
 type ServerConfig struct {
-	Port int `yaml:"port" validate:"required,number"`
+	Port         int  `yaml:"port" validate:"required,number"`
+	CookieSecure bool `yaml:"cookieSecure"`
 }
 
 type MetricsConfig struct {

--- a/pkg/fullhouse/server/server.go
+++ b/pkg/fullhouse/server/server.go
@@ -9,9 +9,6 @@ import (
 	"fullhouse/pkg/fullhouse/metrics"
 	"fullhouse/pkg/fullhouse/models"
 	"fullhouse/pkg/fullhouse/websocket"
-	"github.com/gin-contrib/static"
-	"github.com/gin-gonic/gin"
-	sloggin "github.com/samber/slog-gin"
 	"log/slog"
 	"net/http"
 	"os"
@@ -19,6 +16,10 @@ import (
 	"path"
 	"syscall"
 	"time"
+
+	"github.com/gin-contrib/static"
+	"github.com/gin-gonic/gin"
+	sloggin "github.com/samber/slog-gin"
 )
 
 type Server struct {
@@ -73,6 +74,7 @@ func (s *Server) Start(c config.Config) {
 	api.POST("/participant/new", s.newParticipant)
 	api.Any("/ws", s.wsHandler)
 	api.GET("/info", s.infoHandler)
+	api.GET("/storyPointsMapping", s.storyPointsMappingHandler)
 
 	gameApi := api.Group("/game")
 	gameApi.GET("/votingSchemes", s.votingSchemes)
@@ -102,7 +104,7 @@ func (s *Server) Start(c config.Config) {
 			Handler: metricsHandler,
 		})
 	}
-
+	// Start servers
 	for _, server := range servers {
 		srv := server
 		go func() {
@@ -123,6 +125,11 @@ func (s *Server) Start(c config.Config) {
 			s.log.Error("server forced to shutdown", slog.String("server", server.Addr), slog.Any("error", err))
 		}
 	}
+}
+
+// storyPointsMappingHandler returns the story points mapping from config as JSON
+func (s *Server) storyPointsMappingHandler(ctx *gin.Context) {
+	ctx.JSON(http.StatusOK, config.Configuration.FullHouse.StoryPointsMapping)
 }
 
 func (s *Server) upHandler(ctx *gin.Context) {


### PR DESCRIPTION
## Add configurable story point tooltips and mapping

### Summary:

* Adds backend and frontend support for customizable story point (Fibonacci) value/description pairs.
* Backend now serves a /api/storyPointsMapping endpoint, configurable via YAML.
* Frontend uses NGXS state to load and display these tooltips on voting cards.
* Includes a new story points component for visualizing the mapping.
* Updates documentation and Dockerfile for clarity and multi-platform support.

https://github.com/user-attachments/assets/65cc2581-12d4-49e4-8992-3c1d146a8970

