### PR TITLE
feat: add T-Shirt sizes voting scheme

### DIFF
--- a/config/fullhouse-default.yaml
+++ b/config/fullhouse-default.yaml
@@ -11,3 +11,7 @@ fullHouse:
     - name: Extended Fibonacci
       scheme: [0, 0.25, 0.5, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
       includesQuestionmark: true
+    - name: T-Shirt Sizes
+      scheme: [1, 2, 3, 4, 5, 6]
+      labels: [XS, S, M, L, XL, XXL]
+      includesQuestionmark: true

--- a/frontend/src/app/game/game/game.component.html
+++ b/frontend/src/app/game/game/game.component.html
@@ -27,12 +27,12 @@
             </div>
           }
           @for (p of game.otherParticipants | participantRow: 'top'; track p) {
-            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'"></participant>
+            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'" [votingScheme]="game.votingScheme"></participant>
           }
         </div>
         <div class="row middle-row fx-layout-row fx-align--center-x fx-align--x-center fx-gap--2em" [class.shift-left]="game.otherParticipants.length == 4">
           @for (p of game.otherParticipants | participantRow: 'left'; track p) {
-            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'"></participant>
+            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'" [votingScheme]="game.votingScheme"></participant>
           }
           <div class="table fx-layout-column fx-align--center-x fx-align--x-center">
             @if (game.phase == 'VOTING' && game.voteCount == 0) {
@@ -61,18 +61,18 @@
             }
           </div>
           @for (p of game.otherParticipants | participantRow: 'right'; track p) {
-            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'"></participant>
+            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'" [votingScheme]="game.votingScheme"></participant>
           }
         </div>
         <div class="row bottom-row fx-layout-row fx-align--center-x fx-align--x-start fx-gap--2em">
           @for (p of game.otherParticipants | participantRow: 'bottom_left'; track p) {
-            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'"></participant>
+            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'" [votingScheme]="game.votingScheme"></participant>
           }
           @if (game.self) {
-            <participant [participant]="game.self" [vote]="game.self.vote" [revealed]="game.phase == 'REVEALED'"></participant>
+            <participant [participant]="game.self" [vote]="game.self.vote" [revealed]="game.phase == 'REVEALED'" [votingScheme]="game.votingScheme"></participant>
           }
           @for (p of game.otherParticipants | participantRow: 'bottom_right'; track p) {
-            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'"></participant>
+            <participant [participant]="p" [vote]="p.vote" [revealed]="game.phase == 'REVEALED'" [votingScheme]="game.votingScheme"></participant>
           }
         </div>
       </div>
@@ -89,9 +89,9 @@
   <div class="bottom-menu fx-layout-row fx-align--center-x fx-align--x-center fx-gap--1em">
     @if (game.phase == 'VOTING') {
       <div class="bottom-menu-container">
-        @for (option of game.votingScheme.scheme; track option) {
+        @for (option of game.votingScheme.scheme; track option; let i = $index) {
           <div class="card" (click)="selectOption(option)" [class.selected]="this.game.self?.vote?.vote == option">
-            <span>{{ option | fraction }}</span>
+            <span>{{ game.votingScheme.labels?.[i] ?? (option | fraction) }}</span>
           </div>
         }
         @if (game.votingScheme.includesQuestionmark) {
@@ -105,7 +105,7 @@
       <div class="bottom-menu-container fx-layout-row fx-align--center-x fx-align--x-start fx-gap--4em">
         <div class="fx-layout-column fx-align--center-x fx-align--x-center fx-gap--1em">
           <span class="gray">{{ 'game.average' | translate }}</span>
-          <strong class="large">{{ game.voteAverage | fraction }}</strong>
+          <strong class="large">{{ labelForAverage(game.voteAverage, game.votingScheme) ?? (game.voteAverage | fraction) }}</strong>
         </div>
         <div class="fx-layout-column fx-align--center-x fx-align--x-center fx-gap--1em">
           <span class="gray">{{ 'game.votes' | translate }}</span>

--- a/frontend/src/app/game/game/game.component.ts
+++ b/frontend/src/app/game/game/game.component.ts
@@ -144,7 +144,12 @@ export class GameComponent {
     }
   }
 
-
+  public labelForAverage(average: number, votingScheme: VotingScheme): string | undefined {
+    if (!votingScheme.labels) return undefined;
+    const nearest = votingScheme.scheme.reduce((a, b) => Math.abs(b - average) <= Math.abs(a - average) ? b : a);
+    const index = votingScheme.scheme.indexOf(nearest);
+    return votingScheme.labels[index];
+  }
 
   private getAgreementEmoji(agreement: number | null): string {
     if (agreement == null) {

--- a/frontend/src/app/game/model.ts
+++ b/frontend/src/app/game/model.ts
@@ -14,6 +14,7 @@ export interface Participant {
 export interface VotingScheme {
   name: string;
   scheme: Array<number>;
+  labels?: Array<string>;
   includesQuestionmark: boolean;
 }
 

--- a/frontend/src/app/game/new-game/new-game.component.ts
+++ b/frontend/src/app/game/new-game/new-game.component.ts
@@ -60,7 +60,7 @@ export class NewGameComponent {
 
   private createLabel(scheme: VotingScheme): string {
     let res = `${scheme.name} (`;
-    res += scheme.scheme.map(v => transformToFraction(v)).join(", ")
+    res += scheme.scheme.map((v, i) => scheme.labels?.[i] ?? transformToFraction(v)).join(", ")
     if (scheme.includesQuestionmark) {
       res += `, ?`
     }

--- a/frontend/src/app/game/participant/participant.component.html
+++ b/frontend/src/app/game/participant/participant.component.html
@@ -1,7 +1,7 @@
 <div class="participant fx-layout-column fx-align--center-x fx-align--x-center fx-gap--10px">
   <div class="participant-card fx-layout-row fx-align--center-x fx-align--x-center" [class.voted]="vote?.voted && !revealed" [class.revealed]="vote?.voted && revealed">
     @if (vote && vote.voted && revealed) {
-      <span>{{ vote.vote == '?' ? '?' : (vote.vote | fraction) }}</span>
+      <span>{{ vote.vote == '?' ? '?' : (labelForVote(vote.vote) ?? (vote.vote | fraction)) }}</span>
     }
   </div>
   <strong>{{ participant?.name }}</strong>

--- a/frontend/src/app/game/participant/participant.component.ts
+++ b/frontend/src/app/game/participant/participant.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input} from "@angular/core";
-import {Participant, Vote} from "../model";
+import {Participant, Vote, VotingScheme} from "../model";
 
 @Component({
   selector: 'participant',
@@ -10,4 +10,11 @@ export class ParticipantComponent {
   @Input() participant?: Participant;
   @Input() revealed = false;
   @Input() vote?: Vote | undefined;
+  @Input() votingScheme?: VotingScheme;
+
+  public labelForVote(vote: number | undefined): string | undefined {
+    if (vote == undefined || !this.votingScheme?.labels) return undefined;
+    const index = this.votingScheme.scheme.indexOf(vote);
+    return index >= 0 ? this.votingScheme.labels[index] : undefined;
+  }
 }

--- a/pkg/fullhouse/config/config.go
+++ b/pkg/fullhouse/config/config.go
@@ -59,6 +59,7 @@ type GameConfig struct {
 type VotingScheme struct {
 	Name                 string    `yaml:"name" json:"name" validate:"required"`
 	Scheme               []float32 `yaml:"scheme" json:"scheme" validate:"required,dive,number,min=0"`
+	Labels               []string  `yaml:"labels" json:"labels"`
 	IncludesQuestionmark bool      `yaml:"includesQuestionmark" json:"includesQuestionmark"`
 }
 type Mode string

--- a/pkg/fullhouse/models/game.go
+++ b/pkg/fullhouse/models/game.go
@@ -20,6 +20,7 @@ type Game struct {
 type VotingScheme struct {
 	Name                 string    `json:"name"`
 	Scheme               []float32 `json:"scheme"`
+	Labels               []string  `json:"labels"`
 	IncludesQuestionmark bool      `json:"includesQuestionmark"`
 }
 
@@ -27,6 +28,7 @@ func VotingSchemeFromConfig(scheme config.VotingScheme) VotingScheme {
 	return VotingScheme{
 		Name:                 scheme.Name,
 		Scheme:               scheme.Scheme,
+		Labels:               scheme.Labels,
 		IncludesQuestionmark: scheme.IncludesQuestionmark,
 	}
 }


### PR DESCRIPTION
  **Add label support to voting schemes (T-Shirt Sizes)**                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                       
 - Introduces a built-in T-Shirt Sizes voting scheme (XS, S, M, L, XL, XXL)  
 - Adds an optional labels property to `VotingScheme` that maps human-readable labels onto numeric values in the scheme array                                                                                                                                                                                           
  - Numeric values are preserved internally, so average and agreement calculations continue to work unchanged                                                                                                                                                                                                          
  - All label-aware display falls back gracefully to the existing `fraction` rendering for schemes without labels

<img width="659" height="327" alt="SCR-20260505-hmzz" src="https://github.com/user-attachments/assets/5fb16a4d-5b75-41bd-a1de-0159bcc25ca5" />

<img width="578" height="1088" alt="SCR-20260505-hniz" src="https://github.com/user-attachments/assets/5c3df459-f69b-4ad7-87e9-1009c7b3c38e" />

<img width="481" height="1109" alt="SCR-20260505-hofk" src="https://github.com/user-attachments/assets/204d02bb-b376-47b7-9a2b-7d31f94199c2" />
